### PR TITLE
自分が書いた下書き記事の一覧と詳細を取得するAPIとテストを実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,15 @@
+module Api::V1
+  class Articles::DraftsController < BaseApiController
+    before_action :authenticate_user!
+
+    def index
+      articles = current_user.articles.draft.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      article = current_user.articles.draft.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -23,4 +23,10 @@ class Article < ApplicationRecord
   has_many :article_likes, dependent: :destroy
 
   validates :title, presence: true
+
+  # stringカラムの場合は、enumの定義を以下のようにします
+  enum status: { draft: "draft", published: "published" }
+
+  # draftスコープの定義
+  scope :draft, -> { where(status: :draft) }
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :status, :updated_at
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
+
       resources :articles
     end
   end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -22,5 +22,10 @@ FactoryBot.define do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
     user
+
+    trait :draft do
+      # ステータスが「draft」の場合
+      status { "draft" } # ここでstatusを'draft'に設定
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include Rails.application.routes.url_helpers
 end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  let(:current_user) { create(:user) }
+  let(:headers) { current_user.create_new_auth_token }
+
+  describe "GET /api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    context "自分の書いた下書きの記事が存在するとき" do
+      let!(:article1) { create(:article, :draft, user: current_user) } # rubocop:disable RSpec/IndexedLet
+      let!(:article2) { create(:article, :draft) } # rubocop:disable RSpec/IndexedLet
+
+      it "自分が書いた下書き記事の一覧のみが取得できる" do # rubocop:disable RSpec/MultipleExpectations
+        subject
+        res = JSON.parse(response.body)
+
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 1
+        expect(res[0]["id"]).to eq article1.id
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+  end
+
+  describe "GET /articles/drafts/:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+    context "指定した id の記事が存在して" do
+      let(:article_id) { article.id }
+
+      context "対象の記事が自分が書いた下書きのとき" do
+        let(:article) { create(:article, :draft, user: current_user) }
+
+        it "記事の詳細を取得できる" do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+          subject
+          res = JSON.parse(response.body)
+
+          expect(response).to have_http_status(:ok)
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["status"]).to eq article.status
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(res["user"].keys).to eq ["id", "name", "email"]
+        end
+      end
+
+      context "対象の記事が他のユーザーが書いた下書きのとき" do
+        let(:article) { create(:article, :draft) }
+
+        it "記事が見つからない" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
・ルーティングが生えるように修正
・シリアライザーにstatusカラムを追加
・rubocopが通るようにスペルなど修正
・enumやscopeの設定