### PR TITLE
マイページの一覧表示

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,10 @@
+module Api::V1
+  class Current::ArticlesController < BaseApiController
+    before_action :authenticate_user!
+
+    def index
+      articles = current_user.articles.published.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
+  namespace :api do
+    namespace :v1 do
+      namespace :current do
+        get 'articles/index'
+      end
+    end
+  end
   root to: "home#index"
 
   # reload 対策

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    let(:headers) { current_user.create_new_auth_token }
+    let(:current_user) { create(:user) }
+
+    context "複数の記事が存在するとき" do
+      let!(:article1) { create(:article, :published, user: current_user, updated_at: 1.day.ago) }
+      let!(:article2) { create(:article, :published, user: current_user, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article, :published, user: current_user) }
+
+      before do
+        create(:article, :draft, user: current_user)
+        create(:article, :published)
+      end
+
+      it "自分の書いた公開記事を更新順に取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 3
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+        expect(res[0]["user"]["id"]).to eq current_user.id
+        expect(res[0]["user"]["name"]).to eq current_user.name
+        expect(res[0]["user"]["email"]).to eq current_user.email
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
・ログインユーザーの記事一覧を表示するためにcurrent_articlesを作成
・対応するテストファイルも作成